### PR TITLE
#165164136 Create deleteaccount endpoint

### DIFF
--- a/api/src/controllers/account.controller.js
+++ b/api/src/controllers/account.controller.js
@@ -19,9 +19,11 @@ export default class AccountController {
     const updatedAccount = account.updateAccountStatus({ status, accountNumber }, userId);
 
     if (!updatedAccount.error) {
-      return res
-        .status(updatedAccount.code)
-        .send({ status: updatedAccount.code, data: updatedAccount.data });
+      const response =
+        req.body.status === 'deleted'
+          ? { status: updatedAccount.code, message: updatedAccount.message }
+          : { status: updatedAccount.code, data: updatedAccount.data };
+      return res.status(updatedAccount.code).send(response);
     }
     return res
       .status(updatedAccount.code)

--- a/api/src/routes/account.route.js
+++ b/api/src/routes/account.route.js
@@ -7,5 +7,6 @@ const router = express.Router();
 
 router.post('/accounts', accountController.createAccount);
 router.patch('/account/:accountNumber', accountController.updateAccountStatus);
+router.delete('/account/:accountNumber', accountController.updateAccountStatus);
 
 export default router;

--- a/api/src/services/accounts.service.js
+++ b/api/src/services/accounts.service.js
@@ -93,14 +93,37 @@ export default class AccountService {
         return account.accountNumber === parseInt(update.accountNumber);
       });
       if (accountToUpdate.length) {
-        accountToUpdate[0].status = accountToUpdate[0].status === 'active' ? 'dormant' : 'active';
+        const allowedStatuses = ['deleted', 'dormant', 'active'];
+        if (!allowedStatuses.includes(update.status)) {
+          return {
+            message: `Unidentified status specified`,
+            error: true,
+            code: 400
+          };
+        }
+        if (update.status === 'deleted') {
+          accountToUpdate[0].status = 'deleted';
+          return {
+            message: `Account deleted successfully`,
+            error: false,
+            code: 200
+          };
+        } else {
+          accountToUpdate[0].status = accountToUpdate[0].status === 'active' ? 'dormant' : 'active';
+          return {
+            message: `Account Status successfully updated to '${accountToUpdate[0].status}'`,
+            error: false,
+            code: 200,
+            data: { ...accountToUpdate[0] }
+          };
+        }
+      } else {
+        return {
+          message: `Account number ${update.accountNumber} does not exist`,
+          error: true,
+          code: 404
+        };
       }
-      return {
-        message: `Account Status successfully updated to '${accountToUpdate[0].status}'`,
-        error: false,
-        code: 200,
-        data: { ...accountToUpdate[0] }
-      };
     } else {
       return {
         message: 'You are not authorized to perform this action.',

--- a/api/src/tests/accounts.test.js
+++ b/api/src/tests/accounts.test.js
@@ -94,7 +94,7 @@ describe('Accounts', () => {
         .send(account_status)
         .end((err, res) => {
           expect(account_status).to.have.property('status');
-          res.should.have.status(204);
+          res.should.have.status(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('message');
           done();


### PR DESCRIPTION
#### What does this PR do?
Deletes a bank account

#### Description of Task to be completed?
* Create endpoint to delete an account at /api/v1/account/< account-number >

#### How should this be manually tested?
* run: 
    ```bash
    npm start
    ```
* Do a patch  request to /api/v1/account/< account-number > with sample payload 
    ```javascript
    {
    "status": "deleted",
    "userId": 1
  }
  ```
* Use 1233445642 as test account number

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[#165164136](https://www.pivotaltracker.com/story/show/165164136 "Account delete endpoint")

#### Screenshots (if appropriate)
NA

#### Questions:
NA